### PR TITLE
Add GitHub Codespaces configuration for XTP and MCP.run

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,14 @@
+FROM mcr.microsoft.com/devcontainers/javascript-node:18
+
+# Install additional OS packages
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends \
+    curl \
+    wget \
+    zip \
+    unzip \
+    build-essential
+
+# Set up shell configuration
+COPY .devcontainer/bashrc-additions.sh /tmp/
+RUN cat /tmp/bashrc-additions.sh >> /home/node/.bashrc && rm /tmp/bashrc-additions.sh

--- a/.devcontainer/bashrc-additions.sh
+++ b/.devcontainer/bashrc-additions.sh
@@ -1,0 +1,15 @@
+# XTP CLI shortcuts and helpers
+alias xtp-login="~/xtp-login.sh"
+alias xtp-apps="xtp apps list"
+alias xtp-exts="xtp extension-points list"
+
+# MCP.run shortcuts
+alias mcp-login="~/mcp-login.sh"
+alias mcp-search="mcprun search"
+alias mcp-install="mcprun install"
+
+# Set colors for better readability
+export PS1="\[\033[01;32m\]\u@dev\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ "
+
+# Add useful aliases
+alias ll="ls -la"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,27 @@
+{
+    "name": "XTP & MCP.run Development Environment",
+    "image": "mcr.microsoft.com/devcontainers/javascript-node:18",
+    "features": {
+        "ghcr.io/devcontainers/features/git:1": {},
+        "ghcr.io/devcontainers/features/github-cli:1": {},
+        "ghcr.io/devcontainers/features/go:1": {}
+    },
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "ms-vscode.vscode-typescript-next",
+                "dbaeumer.vscode-eslint",
+                "esbenp.prettier-vscode",
+                "ms-azuretools.vscode-docker",
+                "golang.go"
+            ],
+            "settings": {
+                "editor.formatOnSave": true,
+                "editor.defaultFormatter": "esbenp.prettier-vscode",
+                "terminal.integrated.defaultProfile.linux": "bash"
+            }
+        }
+    },
+    "postCreateCommand": "sh .devcontainer/post-create.sh",
+    "remoteUser": "node"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,9 @@
 {
     "name": "XTP & MCP.run Development Environment",
-    "image": "mcr.microsoft.com/devcontainers/javascript-node:18",
+    "build": {
+        "dockerfile": "Dockerfile",
+        "context": ".."
+    },
     "features": {
         "ghcr.io/devcontainers/features/git:1": {},
         "ghcr.io/devcontainers/features/github-cli:1": {},

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -e
+
+echo "Installing XTP CLI..."
+curl -s https://static.dylibso.com/cli/install.sh | sudo sh
+
+echo "Installing MCP.run CLI..."
+npm install -g @mcp/cli
+
+echo "Setting up environment..."
+
+# Add tools to the PATH
+echo 'export PATH="$PATH:/usr/local/bin"' >> ~/.bashrc
+
+# Create a convenience script for MCP.run login
+cat > ~/mcp-login.sh << 'EOF'
+#!/bin/bash
+echo "Logging into MCP.run..."
+mcprun login
+echo "Login complete! You can now use MCP.run tools."
+EOF
+
+chmod +x ~/mcp-login.sh
+
+# Create a convenience script for XTP login
+cat > ~/xtp-login.sh << 'EOF'
+#!/bin/bash
+echo "To authenticate with XTP, run: export XTP_TOKEN=your_token_here"
+echo "You can get your token from: https://xtp.dylibso.com/tokens"
+EOF
+
+chmod +x ~/xtp-login.sh
+
+echo ""
+echo "Installation complete!"
+echo "To login to MCP.run, run: ~/mcp-login.sh"
+echo "For XTP token instructions, run: ~/xtp-login.sh"

--- a/.vscode/mcprun-playground.code-workspace
+++ b/.vscode/mcprun-playground.code-workspace
@@ -1,0 +1,32 @@
+{
+    "folders": [
+        {
+            "path": ".."
+        }
+    ],
+    "settings": {
+        "editor.formatOnSave": true,
+        "editor.tabSize": 2,
+        "files.exclude": {
+            "**/.git": true,
+            "**/.svn": true,
+            "**/.hg": true,
+            "**/CVS": true,
+            "**/.DS_Store": true,
+            "**/*.js.map": true,
+            "node_modules": true
+        },
+        "terminal.integrated.env.linux": {
+            "PATH": "${env:PATH}:/usr/local/bin"
+        }
+    },
+    "extensions": {
+        "recommendations": [
+            "ms-vscode.vscode-typescript-next",
+            "dbaeumer.vscode-eslint",
+            "esbenp.prettier-vscode",
+            "ms-azuretools.vscode-docker",
+            "golang.go"
+        ]
+    }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,16 @@
+{
+    "editor.formatOnSave": true,
+    "editor.tabSize": 2,
+    "files.exclude": {
+        "**/.git": true,
+        "**/.svn": true,
+        "**/.hg": true,
+        "**/CVS": true,
+        "**/.DS_Store": true,
+        "**/*.js.map": true,
+        "node_modules": true
+    },
+    "terminal.integrated.env.linux": {
+        "PATH": "${env:PATH}:/usr/local/bin"
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,39 @@
 # mcprun-playground
+
+## Development Environment
+
+This repository is configured to work with GitHub Codespaces, providing a fully pre-configured development environment in the cloud.
+
+### Using GitHub Codespaces
+
+1. Click the green "Code" button on the repository page
+2. Select the "Codespaces" tab
+3. Click "Create codespace on add-devcontainer"
+
+The Codespace will automatically install:
+- XTP CLI for working with the XTP plugin system
+- MCP.run CLI for searching and using MCP.run servlets
+- All necessary dependencies and tools
+
+### Authentication
+
+After your Codespace is ready:
+
+- To log in to MCP.run, run: `~/mcp-login.sh`
+- For XTP token setup instructions, run: `~/xtp-login.sh`
+
+### Available Tools and Commands
+
+#### XTP CLI
+- `xtp-login` - Show XTP login instructions
+- `xtp-apps` - List your XTP applications
+- `xtp-exts` - List your XTP extension points
+
+#### MCP.run CLI
+- `mcp-login` - Log in to MCP.run
+- `mcp-search` - Search for MCP.run servlets
+- `mcp-install` - Install MCP.run servlets
+
+## Getting Started
+
+After your Codespace is set up and you've authenticated with the necessary services, you can start developing your XTP plugins or using MCP.run servlets.


### PR DESCRIPTION
This PR adds a GitHub Codespaces configuration for easy development with XTP and MCP.run tools.

## Changes:
- Added `.devcontainer` configuration
- Added custom Dockerfile for the development environment
- Added post-create script to install XTP CLI and MCP.run CLI
- Added VS Code settings and workspace files
- Updated README.md with instructions

## How to use:
1. Click the green "Code" button on the repository page
2. Select the "Codespaces" tab
3. Click "Create codespace on add-devcontainer"

The Codespace will automatically install all necessary tools and dependencies. After starting, use:
- `~/mcp-login.sh` to log in to MCP.run
- `~/xtp-login.sh` to get XTP token setup instructions

Enjoy your fully configured development environment!