### PR TITLE
Add Rust and TypeScript support to the devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -7,7 +7,11 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     wget \
     zip \
     unzip \
-    build-essential
+    build-essential \
+    pkg-config \
+    libssl-dev \
+    llvm \
+    clang
 
 # Set up shell configuration
 COPY .devcontainer/bashrc-additions.sh /tmp/

--- a/.devcontainer/bashrc-additions.sh
+++ b/.devcontainer/bashrc-additions.sh
@@ -8,6 +8,20 @@ alias mcp-login="~/mcp-login.sh"
 alias mcp-search="mcprun search"
 alias mcp-install="mcprun install"
 
+# Rust shortcuts
+alias rs-build="cargo build"
+alias rs-run="cargo run"
+alias rs-test="cargo test"
+alias rs-check="cargo check"
+alias rs-clippy="cargo clippy"
+alias rs-fmt="cargo fmt"
+alias rs-watch="cargo watch -x 'check --tests'"
+
+# TypeScript shortcuts
+alias ts-build="tsc"
+alias ts-run="ts-node"
+alias ts-watch="tsc --watch"
+
 # Set colors for better readability
 export PS1="\[\033[01;32m\]\u@dev\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ "
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,15 @@
     "features": {
         "ghcr.io/devcontainers/features/git:1": {},
         "ghcr.io/devcontainers/features/github-cli:1": {},
-        "ghcr.io/devcontainers/features/go:1": {}
+        "ghcr.io/devcontainers/features/go:1": {},
+        "ghcr.io/devcontainers/features/rust:1": {
+            "version": "latest"
+        },
+        "ghcr.io/devcontainers/features/node:1": {
+            "version": "lts",
+            "nodeGypDependencies": true,
+            "nvmInstallPath": "/usr/local/share/nvm"
+        }
     },
     "customizations": {
         "vscode": {
@@ -16,12 +24,20 @@
                 "dbaeumer.vscode-eslint",
                 "esbenp.prettier-vscode",
                 "ms-azuretools.vscode-docker",
-                "golang.go"
+                "golang.go",
+                "rust-lang.rust-analyzer",
+                "tamasfe.even-better-toml",
+                "serayuzgur.crates"
             ],
             "settings": {
                 "editor.formatOnSave": true,
                 "editor.defaultFormatter": "esbenp.prettier-vscode",
-                "terminal.integrated.defaultProfile.linux": "bash"
+                "terminal.integrated.defaultProfile.linux": "bash",
+                "[rust]": {
+                    "editor.defaultFormatter": "rust-lang.rust-analyzer",
+                    "editor.formatOnSave": true
+                },
+                "rust-analyzer.checkOnSave.command": "clippy"
             }
         }
     },

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -7,10 +7,18 @@ curl -s https://static.dylibso.com/cli/install.sh | sudo sh
 echo "Installing MCP.run CLI..."
 npm install -g @mcp/cli
 
+echo "Setting up TypeScript environment..."
+npm install -g typescript ts-node
+
+echo "Setting up Rust environment..."
+# This is already set up by the features, but we can add additional Rust tools if needed
+rustup component add clippy rustfmt
+cargo install cargo-watch cargo-expand
+
 echo "Setting up environment..."
 
 # Add tools to the PATH
-echo 'export PATH="$PATH:/usr/local/bin"' >> ~/.bashrc
+echo 'export PATH="$PATH:/usr/local/bin:$HOME/.cargo/bin"' >> ~/.bashrc
 
 # Create a convenience script for MCP.run login
 cat > ~/mcp-login.sh << 'EOF'

--- a/README.md
+++ b/README.md
@@ -8,12 +8,14 @@ This repository is configured to work with GitHub Codespaces, providing a fully 
 
 1. Click the green "Code" button on the repository page
 2. Select the "Codespaces" tab
-3. Click "Create codespace on add-devcontainer"
+3. Click "Create codespace on main"
 
 The Codespace will automatically install:
 - XTP CLI for working with the XTP plugin system
 - MCP.run CLI for searching and using MCP.run servlets
-- All necessary dependencies and tools
+- Rust toolchain with Cargo, Clippy, and Rustfmt
+- TypeScript with compiler and ts-node
+- All necessary dependencies and development tools
 
 ### Authentication
 
@@ -34,6 +36,33 @@ After your Codespace is ready:
 - `mcp-search` - Search for MCP.run servlets
 - `mcp-install` - Install MCP.run servlets
 
+#### Rust Shortcuts
+- `rs-build` - Build Rust project (cargo build)
+- `rs-run` - Run Rust project (cargo run)
+- `rs-test` - Run tests (cargo test)
+- `rs-check` - Check code without building (cargo check)
+- `rs-clippy` - Run linter (cargo clippy)
+- `rs-fmt` - Format code (cargo fmt)
+- `rs-watch` - Watch for changes and check (cargo watch)
+
+#### TypeScript Shortcuts
+- `ts-build` - Build TypeScript (tsc)
+- `ts-run` - Run TypeScript directly (ts-node)
+- `ts-watch` - Watch for changes and compile (tsc --watch)
+
 ## Getting Started
 
-After your Codespace is set up and you've authenticated with the necessary services, you can start developing your XTP plugins or using MCP.run servlets.
+After your Codespace is set up and you've authenticated with the necessary services, you can start developing:
+
+### For Rust development:
+1. Create a new Rust project: `cargo new my_project`
+2. Navigate to it: `cd my_project`
+3. Build and run it: `rs-build && rs-run`
+
+### For TypeScript development:
+1. Create a new directory: `mkdir ts-project && cd ts-project`
+2. Initialize a project: `npm init -y`
+3. Create a tsconfig.json: `tsc --init`
+4. Create and run a TypeScript file: `ts-run your-file.ts`
+
+You can use these tools in conjunction with XTP and MCP.run to build plugins and integrate with servlets.


### PR DESCRIPTION
This PR enhances the GitHub Codespaces configuration by adding comprehensive support for Rust and TypeScript development.

## Changes:

### Added to devcontainer.json:
- Rust feature with latest version
- Enhanced Node feature with better TypeScript support
- Added specific IDE extensions for Rust development:
  - rust-analyzer
  - even-better-toml 
  - crates (for Cargo.toml management)
- Added IDE settings for Rust format and analysis

### Added to Dockerfile:
- Additional dependencies for Rust development (pkg-config, libssl-dev, llvm, clang)

### Enhanced post-create.sh:
- Added TypeScript global tools: typescript and ts-node
- Added Rust components: clippy and rustfmt
- Added additional Rust tools: cargo-watch and cargo-expand
- Updated PATH to include Rust's binaries

### Added convenient aliases:
- Rust shortcuts: rs-build, rs-run, rs-test, rs-check, rs-clippy, rs-fmt, rs-watch
- TypeScript shortcuts: ts-build, ts-run, ts-watch

### Updated README.md:
- Added documentation for all Rust and TypeScript features
- Added quick-start guides for both languages

## How to Use:

After starting a Codespace, you'll have access to:
- A complete Rust development environment with cargo and common tools
- TypeScript with compiler and runtime support
- Convenient aliases to speed up common tasks

The VS Code environment is also pre-configured with appropriate extensions and settings for both languages.