### PR TITLE
Fix MCP CLI name and add WebAssembly support

### DIFF
--- a/.devcontainer/bashrc-additions.sh
+++ b/.devcontainer/bashrc-additions.sh
@@ -5,8 +5,10 @@ alias xtp-exts="xtp extension-points list"
 
 # MCP.run shortcuts
 alias mcp-login="~/mcp-login.sh"
-alias mcp-search="mcprun search"
-alias mcp-install="mcprun install"
+alias mcp-search="mcpx search"
+alias mcp-install="mcpx install"
+alias mcp-publish="xtp plugin push"
+alias mcp-servlet-lab="npx --yes -p @dylibso/mcpx@latest servlet-lab"
 
 # Rust shortcuts
 alias rs-build="cargo build"
@@ -16,11 +18,17 @@ alias rs-check="cargo check"
 alias rs-clippy="cargo clippy"
 alias rs-fmt="cargo fmt"
 alias rs-watch="cargo watch -x 'check --tests'"
+alias rs-wasm="wasm-pack build"
 
 # TypeScript shortcuts
 alias ts-build="tsc"
 alias ts-run="ts-node"
 alias ts-watch="tsc --watch"
+
+# WebAssembly helpers
+alias wasm-build="xtp plugin build"
+alias wasm-call="xtp plugin call"
+alias wasm-test="xtp plugin test"
 
 # Set colors for better readability
 export PS1="\[\033[01;32m\]\u@dev\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ "

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -4,16 +4,17 @@ set -e
 echo "Installing XTP CLI..."
 curl -s https://static.dylibso.com/cli/install.sh | sudo sh
 
-echo "Installing MCP.run CLI..."
-npm install -g @mcp/cli
+echo "Installing MCP.run CLI (mcpx)..."
+npm install -g @dylibso/mcpx
 
 echo "Setting up TypeScript environment..."
 npm install -g typescript ts-node
 
-echo "Setting up Rust environment..."
-# This is already set up by the features, but we can add additional Rust tools if needed
+echo "Setting up Rust environment with WebAssembly target..."
+# This is already set up by the features, but we add WebAssembly target and tools
+rustup target add wasm32-wasi wasm32-unknown-unknown
 rustup component add clippy rustfmt
-cargo install cargo-watch cargo-expand
+cargo install cargo-watch cargo-expand wasm-pack
 
 echo "Setting up environment..."
 
@@ -24,7 +25,7 @@ echo 'export PATH="$PATH:/usr/local/bin:$HOME/.cargo/bin"' >> ~/.bashrc
 cat > ~/mcp-login.sh << 'EOF'
 #!/bin/bash
 echo "Logging into MCP.run..."
-mcprun login
+mcpx login
 echo "Login complete! You can now use MCP.run tools."
 EOF
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ This repository is configured to work with GitHub Codespaces, providing a fully 
 
 The Codespace will automatically install:
 - XTP CLI for working with the XTP plugin system
-- MCP.run CLI for searching and using MCP.run servlets
-- Rust toolchain with Cargo, Clippy, and Rustfmt
+- MCP.run CLI (mcpx) for searching and using MCP.run servlets
+- Rust toolchain with Cargo, Clippy, and WebAssembly targets
 - TypeScript with compiler and ts-node
 - All necessary dependencies and development tools
 
@@ -35,6 +35,13 @@ After your Codespace is ready:
 - `mcp-login` - Log in to MCP.run
 - `mcp-search` - Search for MCP.run servlets
 - `mcp-install` - Install MCP.run servlets
+- `mcp-publish` - Publish a servlet (uses xtp plugin push)
+- `mcp-servlet-lab` - Test a servlet locally
+
+#### WebAssembly Tools
+- `wasm-build` - Build a WebAssembly plugin (xtp plugin build)
+- `wasm-call` - Call a WebAssembly plugin function (xtp plugin call)
+- `wasm-test` - Test a WebAssembly plugin (xtp plugin test)
 
 #### Rust Shortcuts
 - `rs-build` - Build Rust project (cargo build)
@@ -44,6 +51,7 @@ After your Codespace is ready:
 - `rs-clippy` - Run linter (cargo clippy)
 - `rs-fmt` - Format code (cargo fmt)
 - `rs-watch` - Watch for changes and check (cargo watch)
+- `rs-wasm` - Build as WebAssembly (wasm-pack build)
 
 #### TypeScript Shortcuts
 - `ts-build` - Build TypeScript (tsc)
@@ -54,15 +62,26 @@ After your Codespace is ready:
 
 After your Codespace is set up and you've authenticated with the necessary services, you can start developing:
 
-### For Rust development:
-1. Create a new Rust project: `cargo new my_project`
-2. Navigate to it: `cd my_project`
-3. Build and run it: `rs-build && rs-run`
+### For Rust WebAssembly Servlet:
+1. Create a servlet using the XTP CLI: 
+   ```
+   xtp plugin init --feature stub-with-code-samples --path my_servlet
+   ```
+2. Choose Rust when prompted
+3. Navigate to it: `cd my_servlet`
+4. Implement the functions in `src/lib.rs`
+5. Build it: `wasm-build`
+6. Test it: `wasm-call dist/plugin.wasm describe --wasi`
 
-### For TypeScript development:
-1. Create a new directory: `mkdir ts-project && cd ts-project`
-2. Initialize a project: `npm init -y`
-3. Create a tsconfig.json: `tsc --init`
-4. Create and run a TypeScript file: `ts-run your-file.ts`
+### For TypeScript Servlet:
+1. Create a servlet using the XTP CLI:
+   ```
+   xtp plugin init --feature stub-with-code-samples --path ts-servlet
+   ```
+2. Choose TypeScript when prompted
+3. Navigate to it: `cd ts-servlet`
+4. Implement the functions in `src/main.ts`
+5. Build it: `wasm-build`
+6. Test it locally with: `mcp-servlet-lab --servlet dist/plugin.wasm`
 
-You can use these tools in conjunction with XTP and MCP.run to build plugins and integrate with servlets.
+You can publish your servlet to MCP.run with `mcp-publish` once you've registered it at [mcp.run/publish](https://mcp.run/publish).


### PR DESCRIPTION
This PR includes two important fixes:

1. **Correct MCP CLI Name**: 
   - Changed from the incorrect `@mcp/cli` to the actual `@dylibso/mcpx` npm package
   - Updated all references to command names from `mcprun` to `mcpx`
   - Added additional helpful aliases for servlet development and testing

2. **Added WebAssembly Support for Rust**:
   - Added WebAssembly targets to Rust: `wasm32-wasi` and `wasm32-unknown-unknown`
   - Added `wasm-pack` installation for better WebAssembly package management
   - Created convenient aliases for WebAssembly development: `wasm-build`, `wasm-call`, `wasm-test`
   - Added a Rust WebAssembly alias: `rs-wasm`

3. **Expanded Documentation**:
   - Updated README.md with more accurate and expanded WebAssembly/servlet development instructions
   - Added examples of creating and testing servlets with both Rust and TypeScript
   - Improved the command reference section

These changes make the development environment fully ready for creating, testing, and publishing MCP.run servlets with proper WebAssembly support.