### PR TITLE
Add TinyGo support for Go WebAssembly servlet development

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -11,7 +11,14 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     pkg-config \
     libssl-dev \
     llvm \
-    clang
+    clang \
+    xz-utils \
+    binaryen
+
+# Install TinyGo
+RUN curl -L -o tinygo.tar.gz https://github.com/tinygo-org/tinygo/releases/download/v0.30.0/tinygo_0.30.0_amd64.tar.gz \
+    && tar -C /usr/local -xzf tinygo.tar.gz \
+    && rm tinygo.tar.gz
 
 # Set up shell configuration
 COPY .devcontainer/bashrc-additions.sh /tmp/

--- a/.devcontainer/bashrc-additions.sh
+++ b/.devcontainer/bashrc-additions.sh
@@ -20,6 +20,19 @@ alias rs-fmt="cargo fmt"
 alias rs-watch="cargo watch -x 'check --tests'"
 alias rs-wasm="wasm-pack build"
 
+# Go shortcuts
+alias go-build="go build"
+alias go-run="go run"
+alias go-test="go test"
+alias go-fmt="go fmt"
+
+# TinyGo shortcuts
+alias tgo-build="tinygo build"
+alias tgo-run="tinygo run"
+alias tgo-build-wasm="tinygo build -target wasm"
+alias tgo-build-wasi="tinygo build -target wasi"
+alias tgo-build-servlet="tinygo build -target wasi -o dist/plugin.wasm"
+
 # TypeScript shortcuts
 alias ts-build="tsc"
 alias ts-run="ts-node"

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -16,10 +16,90 @@ rustup target add wasm32-wasi wasm32-unknown-unknown
 rustup component add clippy rustfmt
 cargo install cargo-watch cargo-expand wasm-pack
 
-echo "Setting up environment..."
+echo "Configuring TinyGo..."
+# Setup TinyGo environment variables and add to PATH
+echo 'export TINYGOROOT=/usr/local/tinygo' >> ~/.bashrc
+echo 'export PATH="$PATH:/usr/local/bin:$HOME/.cargo/bin:/usr/local/tinygo/bin"' >> ~/.bashrc
 
-# Add tools to the PATH
-echo 'export PATH="$PATH:/usr/local/bin:$HOME/.cargo/bin"' >> ~/.bashrc
+# Create a sample Go servlet directory
+mkdir -p ~/samples/go-servlet
+cat > ~/samples/go-servlet/main.go << 'EOF'
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+
+	pdk "github.com/extism/go-pdk"
+)
+
+//export call
+func call() int32 {
+	input := pdk.Input()
+	var request map[string]interface{}
+	json.Unmarshal(input, &request)
+
+	params, ok := request["params"].(map[string]interface{})
+	if !ok {
+		return 1
+	}
+
+	args, ok := params["arguments"].(map[string]interface{})
+	if !ok {
+		return 1
+	}
+
+	name, ok := args["name"].(string)
+	if !ok {
+		name = "world"
+	}
+
+	result := map[string]interface{}{
+		"content": []map[string]interface{}{
+			{
+				"type": "text",
+				"text": fmt.Sprintf("Hello, %s! This is a Go servlet built with TinyGo.", name),
+			},
+		},
+	}
+
+	resultJSON, _ := json.Marshal(result)
+	mem := pdk.AllocateString(string(resultJSON))
+	pdk.OutputMemory(mem)
+
+	return 0
+}
+
+//export describe
+func describe() int32 {
+	description := `{
+		"tools": [
+			{
+				"name": "greet",
+				"description": "A simple greeting tool built with TinyGo",
+				"inputSchema": {
+					"type": "object",
+					"properties": {
+						"name": {
+							"type": "string",
+							"description": "The name to greet"
+						}
+					}
+				}
+			}
+		]
+	}`
+
+	mem := pdk.AllocateString(description)
+	pdk.OutputMemory(mem)
+
+	return 0
+}
+
+func main() {}
+EOF
+
+echo "Setting up environment..."
 
 # Create a convenience script for MCP.run login
 cat > ~/mcp-login.sh << 'EOF'
@@ -44,3 +124,4 @@ echo ""
 echo "Installation complete!"
 echo "To login to MCP.run, run: ~/mcp-login.sh"
 echo "For XTP token instructions, run: ~/xtp-login.sh"
+echo "TinyGo is installed and ready to use for building Go WebAssembly servlets"

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The Codespace will automatically install:
 - XTP CLI for working with the XTP plugin system
 - MCP.run CLI (mcpx) for searching and using MCP.run servlets
 - Rust toolchain with Cargo, Clippy, and WebAssembly targets
+- Go with TinyGo for WebAssembly compilation
 - TypeScript with compiler and ts-node
 - All necessary dependencies and development tools
 
@@ -53,6 +54,19 @@ After your Codespace is ready:
 - `rs-watch` - Watch for changes and check (cargo watch)
 - `rs-wasm` - Build as WebAssembly (wasm-pack build)
 
+#### Go Shortcuts
+- `go-build` - Build Go project (go build)
+- `go-run` - Run Go project (go run)
+- `go-test` - Run tests (go test)
+- `go-fmt` - Format code (go fmt)
+
+#### TinyGo Shortcuts
+- `tgo-build` - Build with TinyGo (tinygo build)
+- `tgo-run` - Run with TinyGo (tinygo run)
+- `tgo-build-wasm` - Build WebAssembly (tinygo build -target wasm)
+- `tgo-build-wasi` - Build WASI (tinygo build -target wasi)
+- `tgo-build-servlet` - Build servlet (tinygo build -target wasi -o dist/plugin.wasm)
+
 #### TypeScript Shortcuts
 - `ts-build` - Build TypeScript (tsc)
 - `ts-run` - Run TypeScript directly (ts-node)
@@ -73,6 +87,17 @@ After your Codespace is set up and you've authenticated with the necessary servi
 5. Build it: `wasm-build`
 6. Test it: `wasm-call dist/plugin.wasm describe --wasi`
 
+### For Go WebAssembly Servlet:
+1. Create a servlet using the XTP CLI:
+   ```
+   xtp plugin init --feature stub-with-code-samples --path go-servlet
+   ```
+2. Choose Go when prompted
+3. Navigate to it: `cd go-servlet`
+4. Implement the functions in `main.go`
+5. Build it with TinyGo: `tgo-build-servlet`
+6. Test it: `wasm-call dist/plugin.wasm describe --wasi`
+
 ### For TypeScript Servlet:
 1. Create a servlet using the XTP CLI:
    ```
@@ -85,3 +110,15 @@ After your Codespace is set up and you've authenticated with the necessary servi
 6. Test it locally with: `mcp-servlet-lab --servlet dist/plugin.wasm`
 
 You can publish your servlet to MCP.run with `mcp-publish` once you've registered it at [mcp.run/publish](https://mcp.run/publish).
+
+## Sample Go Servlet
+
+A sample Go servlet is provided in `~/samples/go-servlet/main.go`. To build it:
+
+1. Navigate to it: `cd ~/samples/go-servlet`
+2. Build it with TinyGo: `tgo-build-servlet`
+3. Test it: `wasm-call dist/plugin.wasm describe --wasi`
+4. Try calling the greet function: 
+   ```
+   wasm-call dist/plugin.wasm call --input='{"params":{"name":"greet","arguments":{"name":"YourName"}}}' --wasi
+   ```


### PR DESCRIPTION
This PR adds comprehensive TinyGo support to the Codespace, which is essential for compiling Go code to WebAssembly for MCP.run servlets.

## Changes:

1. **TinyGo Installation**:
   - Added TinyGo 0.30.0 to the Dockerfile, along with its dependencies
   - Added necessary environment variables for TinyGo in the post-create.sh script

2. **Go and TinyGo Shortcuts**:
   - Added standard Go shortcuts: `go-build`, `go-run`, `go-test`, `go-fmt`
   - Added TinyGo-specific shortcuts: 
     - `tgo-build` - Regular TinyGo build
     - `tgo-run` - Run with TinyGo
     - `tgo-build-wasm` - Build WebAssembly with TinyGo
     - `tgo-build-wasi` - Build WASI with TinyGo
     - `tgo-build-servlet` - Special shortcut for building servlets

3. **Sample Go Servlet**:
   - Added a sample Go servlet to `~/samples/go-servlet/main.go`
   - The sample implements a simple greeting service that demonstrates the Extism PDK usage

4. **Documentation**:
   - Updated README.md with Go and TinyGo information
   - Added a dedicated section on how to build a Go WebAssembly servlet
   - Added instructions for using the sample servlet

This PR completes the servlet development environment by supporting all three primary languages used for building MCP.run servlets: TypeScript, Rust, and Go (via TinyGo).